### PR TITLE
Refactor `StaticModule.__getattr__` and fix `ast.AnnAssign` edge case

### DIFF
--- a/setuptools/config/expand.py
+++ b/setuptools/config/expand.py
@@ -66,11 +66,11 @@ class StaticModule:
         vars(self).update(locals())
         del self.self
 
-    def _find_assignments(self) -> Iterator[Tuple[ast.AST, Optional[ast.AST]]]:
+    def _find_assignments(self) -> Iterator[Tuple[ast.AST, ast.AST]]:
         for statement in self.module.body:
             if isinstance(statement, ast.Assign):
                 yield from ((target, statement.value) for target in statement.targets)
-            elif isinstance(statement, ast.AnnAssign):
+            elif isinstance(statement, ast.AnnAssign) and statement.value:
                 yield (statement.target, statement.value)
 
     def __getattr__(self, attr):

--- a/setuptools/tests/config/test_expand.py
+++ b/setuptools/tests/config/test_expand.py
@@ -85,13 +85,17 @@ class TestReadAttr:
         values = expand.read_attr('lib.mod.VALUES', {'lib': 'pkg/sub'}, tmp_path)
         assert values['c'] == (0, 1, 1)
 
-    def test_read_annotated_attr(self, tmp_path):
+    @pytest.mark.parametrize(
+        "example",
+        [
+            "VERSION: str\nVERSION = '0.1.1'\nraise SystemExit(1)\n",
+            "VERSION: str = '0.1.1'\nraise SystemExit(1)\n",
+        ]
+    )
+    def test_read_annotated_attr(self, tmp_path, example):
         files = {
             "pkg/__init__.py": "",
-            "pkg/sub/__init__.py": (
-                "VERSION: str = '0.1.1'\n"
-                "raise SystemExit(1)\n"
-            ),
+            "pkg/sub/__init__.py": example,
         }
         write_files(files, tmp_path)
         # Make sure this attribute can be read statically


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

As discussed in https://github.com/pypa/setuptools/pull/3391#issuecomment-1159642050, this suggestion includes:

- A refactoring of `StaticModule.__getattr__` that introduces back the generators and avoids the duplication in raising exceptions.
- A fix for the edge case when `ast.AnnAssign` has a `None` value
- Tests to ensure the fix works.

Closes <!-- issue number here -->

### Pull Request Checklist
- [x] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
